### PR TITLE
Fix: output Astro build to dist-next on next branch

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,8 +6,11 @@ import sitemap from "@astrojs/sitemap";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 
+const isNextBranch = process.env.GITHUB_REF_NAME === 'next';
+
 export default defineConfig({
   site: "https://william64.com",
+  outDir: isNextBranch ? './dist-next' : './dist',
   integrations: [
     react(),
     tailwind(),


### PR DESCRIPTION
## Summary
- Check `GITHUB_REF_NAME` env var to detect next branch
- Output build to `dist-next/` when building the `next` branch
- Defaults to `dist/` for all other branches

This fixes the ServerStatsWidget not appearing on next.william64.com — the build was going to `dist/` but the server served from `dist-next/`.